### PR TITLE
Allow configuration without a password

### DIFF
--- a/lib/capistrano/db_sync/postgres/cli.rb
+++ b/lib/capistrano/db_sync/postgres/cli.rb
@@ -4,11 +4,11 @@ class Capistrano::DBSync::Postgres::CLI
   end
 
   def dump(to_file, db, options = [])
-    "#{with_pw} pg_dump #{credentials} #{format_args} -f #{to_file} #{options.join(' ')} #{db}"
+    "#{with_pw} pg_dump #{credentials} #{format_args} -f #{to_file} #{options.join(' ')} #{db}".strip
   end
 
   def restore(from_file, db, options = [])
-    "#{with_pw} pg_restore #{credentials} #{format_args} -d #{db} #{options.join(' ')} #{from_file}"
+    "#{with_pw} pg_restore #{credentials} #{format_args} -d #{db} #{options.join(' ')} #{from_file}".strip
   end
 
   def drop_db(db)
@@ -64,7 +64,9 @@ class Capistrano::DBSync::Postgres::CLI
   end
 
   def with_pw
-    "PGPASSWORD='#{config['password']}'" unless config.fetch('password', '').empty?
+    unless (config['password'] || '').empty?
+      "PGPASSWORD='#{config['password']}'"
+    end
   end
 
   attr_reader :config, :session_id

--- a/spec/lib/capistrano/db_sync/postgres/cli_spec.rb
+++ b/spec/lib/capistrano/db_sync/postgres/cli_spec.rb
@@ -1,30 +1,69 @@
 require 'spec_helper'
 
-describe Capistrano::DBSync::Postgres::CLI do
-  let(:config) do
-    {
-      "database" => "staging",
-      "username" => "user",
-      "password" => "pw",
-      "adapter"  => "postgresql",
-      "host"     => "127.0.0.1",
-      "port"     => "5432",
-    }
-  end
+describe "Using a regular config" do
 
-  let(:cli) { Capistrano::DBSync::Postgres::CLI.new(config) }
+  describe Capistrano::DBSync::Postgres::CLI do
+    let(:config) do
+      {
+        "database" => "staging",
+        "username" => "user",
+        "password" => "pw",
+        "adapter"  => "postgresql",
+        "host"     => "127.0.0.1",
+        "port"     => "5432",
+      }
+    end
 
-  describe "#dump" do
-    it "generates pg_dump command" do
-      command = cli.dump("/tmp/staging.dump", "staging", ["--section=pre-data"])
-      command.must_equal "PGPASSWORD='pw' pg_dump -U user -h 127.0.0.1 -p 5432 --no-acl --no-owner --format=custom -f /tmp/staging.dump --section=pre-data staging"
+    let(:cli) { Capistrano::DBSync::Postgres::CLI.new(config) }
+
+    describe "#dump" do
+      it "generates pg_dump command" do
+        command = cli.dump("/tmp/staging.dump", "staging", ["--section=pre-data"])
+        command.must_equal "PGPASSWORD='pw' pg_dump -U user -h 127.0.0.1 -p 5432 --no-acl --no-owner --format=custom -f /tmp/staging.dump --section=pre-data staging"
+      end
+    end
+
+    describe "#restore" do
+      it "generates pg_dump command" do
+        command = cli.restore("/db/production.dump", "staging", ["--jobs=3"])
+        command.must_equal "PGPASSWORD='pw' pg_restore -U user -h 127.0.0.1 -p 5432 --no-acl --no-owner --format=custom -d staging --jobs=3 /db/production.dump"
+      end
     end
   end
 
-  describe "#restore" do
-    it "generates pg_dump command" do
-      command = cli.restore("/db/production.dump", "staging", ["--jobs=3"])
-      command.must_equal "PGPASSWORD='pw' pg_restore -U user -h 127.0.0.1 -p 5432 --no-acl --no-owner --format=custom -d staging --jobs=3 /db/production.dump"
-    end
-  end
 end
+
+
+describe "Using a config without a password" do
+
+  describe Capistrano::DBSync::Postgres::CLI do
+    let(:config) do
+      {
+        "database" => "staging",
+        "username" => "user",
+        "password" => nil,
+        "adapter"  => "postgresql",
+        "host"     => "127.0.0.1",
+        "port"     => "5432",
+      }
+    end
+
+    let(:cli) { Capistrano::DBSync::Postgres::CLI.new(config) }
+
+    describe "#dump" do
+      it "generates pg_dump command" do
+        command = cli.dump("/tmp/staging.dump", "staging", ["--section=pre-data"])
+        command.must_equal "pg_dump -U user -h 127.0.0.1 -p 5432 --no-acl --no-owner --format=custom -f /tmp/staging.dump --section=pre-data staging"
+      end
+    end
+
+    describe "#restore" do
+      it "generates pg_dump command" do
+        command = cli.restore("/db/production.dump", "staging", ["--jobs=3"])
+        command.must_equal "pg_restore -U user -h 127.0.0.1 -p 5432 --no-acl --no-owner --format=custom -d staging --jobs=3 /db/production.dump"
+      end
+    end
+  end
+
+end
+


### PR DESCRIPTION
Hi,

I have a development configuration without a password.

The gem assumes that the `password` key (in the config Hash) is either missing or a String.
But if it's set to `nil` a `NoMethodError` is raised.

I've added a very naive test and implementation.
